### PR TITLE
feat: expose the underlying timer so that it can be started manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ The timer you want to use to measure how long the code took to run, by default
 match the [@dbpiper/timer][@dbpiper/timer] API.
 
 The timer will start measuring from the moment that the instance object is
-created, thus it should not be created until measurement start is desired.
+created, by default. However, you may also use slackNotifyStatus.timer to get
+the instance of the timer and then you can manually start it when ready
+with timer.start. See [@dbpiper/timer][@dbpiper/timer] for more details
+on the timer API.
 
 #### SlackNotifyStatusOptions.scriptName
 
@@ -86,6 +89,16 @@ The name of the script you are sending messages on behalf of, by default this
 is 'Verification', as this is the name of my script.
 
 ---
+
+### slackNotifyStatus.timer
+
+return type: `Timer`
+
+Gets the [@dbpiper/timer][@dbpiper/timer] instance object which is being
+used to measure the time. This can then be used to start the timer manually,
+which is useful if you want to create the SlackNotifyStatus instance object
+_before_ you want to begin measuring the time taken. See
+[@dbpiper/timer][@dbpiper/timer] for more details on the timer API.
 
 ### slackNotifyStatus.slackSendMessage(success = true, mock = false)
 

--- a/src/__tests__/slack-notify-status.test.ts
+++ b/src/__tests__/slack-notify-status.test.ts
@@ -1,5 +1,6 @@
 // tslint:disable: no-magic-numbers
 
+import Timer from '@dbpiper/timer';
 import _ from 'lodash';
 import { CoreOptions } from 'request';
 import { promisify } from 'util';
@@ -32,6 +33,29 @@ jest.mock('request', () => {
 import SlackNotifyStatus from '../slack-notify-status';
 
 describe('slackNotifyStatus instance tests', () => {
+  describe('slackNotifyStatus.timer tests', () => {
+    test('basic timer access', () => {
+      const slackNotifyStatus = new SlackNotifyStatus({
+        slackUrl: 'hello',
+        slackChannel: 'hello',
+      });
+
+      const timer = slackNotifyStatus.timer;
+      expect(timer instanceof Timer).toBe(true);
+    });
+
+    test('makes a timer and returns it if it was undefined', () => {
+      const slackNotifyStatus = new SlackNotifyStatus({
+        slackUrl: 'hello',
+        slackChannel: 'hello',
+        timer: undefined,
+      });
+
+      const timer = slackNotifyStatus.timer;
+      expect(timer instanceof Timer).toBe(true);
+    });
+  });
+
   describe('slackNotifyStatus.slackSendMessage tests', () => {
     test('slack post message success test', async () => {
       const slackNotifyStatus = new SlackNotifyStatus({

--- a/src/slack-notify-status.ts
+++ b/src/slack-notify-status.ts
@@ -26,6 +26,16 @@ export class SlackNotifyStatus {
 
   private _options: SlackNotifyStatusOptions;
 
+  get timer(): Timer {
+    if (SlackNotifyStatus.isDefined(this._options.timer)) {
+      return this._options.timer;
+    }
+
+    // if the timer is not already created make a new one
+    this._options.timer = new Timer();
+    return this._options.timer;
+  }
+
   /**
    * Creates an instance of SlackNotifyStatus.
    * @param {SlackNotifyStatusOptions} options The options to use to configure
@@ -43,6 +53,10 @@ export class SlackNotifyStatus {
       ...options,
     };
     this._options = combinedOptions;
+
+    if (!SlackNotifyStatus.isDefined(this._options.timer)) {
+      this._options.timer = new Timer();
+    }
   }
   /**
    *


### PR DESCRIPTION
Until now the timer only ever started when the instance object was
created, however it is often convenient to create the instance
object early and then start the timer later on. This adds support
for this, by adding an accessor to underlying timer, in other
words the user can now call slackNotifyStatus.timer.start()
whenever they wish.